### PR TITLE
Removing unnecessary conversions

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -29,3 +29,4 @@
 ### UE5 Preview 1 (LWC Double Precision) Changes
 [Darcul](https://github.com/Darcul)
 [connorjak](https://github.com/connorjak)
+[sfla](https://github.com/sfla)

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
@@ -163,12 +163,12 @@ bool URuntimeMeshProviderCollision::GetCollisionMesh(FRuntimeMeshCollisionData& 
 			{
 				if (ChannelId < CachedSection.TexCoords.NumChannels() && CachedSection.TexCoords.NumTexCoords(ChannelId) > Index)
 				{
-					FVector2f TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
+					FVector2D TexCoord = CachedSection.TexCoords.GetTexCoord(ChannelId, Index);
 					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, TexCoord);
 				}
 				else
 				{
-					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2f::ZeroVector);
+					CollisionData.TexCoords.SetTexCoord(ChannelId, Index, FVector2D::ZeroVector);
 				}
 			}
 		}

--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -492,7 +492,7 @@ bool URuntimeMeshProviderStatic::GetCollisionMesh(FRuntimeMeshCollisionData& Col
 							}
 							for (int32 ChannelIdx = 0; ChannelIdx < NumChannels; ChannelIdx++)
 							{
-								CollisionData.TexCoords.SetTexCoord(ChannelIdx, FirstVertex + VertIdx, SectionData.TexCoords.GetTexCoord(VertIdx, ChannelIdx));
+								CollisionData.TexCoords.SetTexCoord(ChannelIdx, FirstVertex + VertIdx, FVector2D(SectionData.TexCoords.GetTexCoord(VertIdx, ChannelIdx)));
 							}
 						}
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -547,7 +547,7 @@ bool URuntimeMesh::GetPhysicsTriMeshData(struct FTriMeshCollisionData* Collision
 			CollisionData->Vertices = RMC_ConvertTArray<FVector3f>(CollisionMesh.Vertices.TakeContents());
 			CollisionData->Indices = CollisionMesh.Triangles.TakeContents();
 			//TODO might need to implement a 2D form of RMC_ConvertTArray for performance / correctness?
-			CollisionData->UVs = RMC_ConvertTArray<TArray<FVector2D>>(CollisionMesh.TexCoords.TakeContents()); //TODO might need to implement a 2D form of RMC_ConvertTArray
+			CollisionData->UVs = CollisionMesh.TexCoords.TakeContents(); //TODO might need to implement a 2D form of RMC_ConvertTArray
 			CollisionData->MaterialIndices = CollisionMesh.MaterialIndices.TakeContents();
 
 			CollisionData->bDeformableMesh = CollisionMesh.bDeformableMesh;

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -546,8 +546,7 @@ bool URuntimeMesh::GetPhysicsTriMeshData(struct FTriMeshCollisionData* Collision
 		{
 			CollisionData->Vertices = RMC_ConvertTArray<FVector3f>(CollisionMesh.Vertices.TakeContents());
 			CollisionData->Indices = CollisionMesh.Triangles.TakeContents();
-			//TODO might need to implement a 2D form of RMC_ConvertTArray for performance / correctness?
-			CollisionData->UVs = CollisionMesh.TexCoords.TakeContents(); //TODO might need to implement a 2D form of RMC_ConvertTArray
+			CollisionData->UVs = CollisionMesh.TexCoords.TakeContents();
 			CollisionData->MaterialIndices = CollisionMesh.MaterialIndices.TakeContents();
 
 			CollisionData->bDeformableMesh = CollisionMesh.bDeformableMesh;

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -949,7 +949,7 @@ void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 			for (const FRuntimeMeshCollisionConvexMesh& Convex : CollisionSettings.ConvexElements)
 			{
 				FKConvexElem& NewConvexElem = *new(ConvexElems) FKConvexElem();
-				NewConvexElem.VertexData = RMC_ConvertTArray<FVector>(Convex.VertexBuffer);
+				NewConvexElem.VertexData = Convex.VertexBuffer;
 				// TODO: Store this on the section so we don't have to compute it on each cook
 				NewConvexElem.ElemBox = FBox(Convex.BoundingBox);
 			}

--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -544,7 +544,7 @@ bool URuntimeMesh::GetPhysicsTriMeshData(struct FTriMeshCollisionData* Collision
 
 		if (MeshProviderPtr->GetCollisionMesh(CollisionMesh))
 		{
-			CollisionData->Vertices = RMC_ConvertTArray<FVector3f>(CollisionMesh.Vertices.TakeContents());
+			CollisionData->Vertices = CollisionMesh.Vertices.TakeContents();
 			CollisionData->Indices = CollisionMesh.Triangles.TakeContents();
 			CollisionData->UVs = CollisionMesh.TexCoords.TakeContents();
 			CollisionData->MaterialIndices = CollisionMesh.MaterialIndices.TakeContents();

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
@@ -210,7 +210,7 @@ FRuntimeMeshRenderableCollisionData::FRuntimeMeshRenderableCollisionData(const F
 	{
 		for (int32 ChannelId = 0; ChannelId < NumChannels; ChannelId++)
 		{
-			TexCoords.SetTexCoord(ChannelId, Index, InRenderable.TexCoords.GetTexCoord(Index, ChannelId));
+			TexCoords.SetTexCoord(ChannelId, Index, FVector2D(InRenderable.TexCoords.GetTexCoord(Index, ChannelId)));
 		}
 	}
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -83,7 +83,7 @@ int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLOD
 		// Copy UV's
 		for (int32 UVIndex = 0; UVIndex < NumUVChannels; UVIndex++)
 		{
-			NewMeshData.TexCoords.Add(UVIndex, (FVector2f)LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex));
+			NewMeshData.TexCoords.Add(UVIndex, FVector2D(LOD.VertexBuffers.StaticMeshVertexBuffer.GetVertexUV(VertexIndex, UVIndex)));
 		}
 		
 		MeshToSectionVertexMap.Add(VertexIndex, NewVertexIndex);

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -198,7 +198,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings
 	{
 		bHadSimple = true;
 		OutCollisionSettings.ConvexElements.Emplace(
-			RMC_ConvertTArray<FVector3f>(SourceConvexElems[ConvexIndex].VertexData), 
+			SourceConvexElems[ConvexIndex].VertexData, 
 			FBox3f(SourceConvexElems[ConvexIndex].ElemBox));
 	}
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -199,7 +199,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshCollisionToCollisionSettings
 		bHadSimple = true;
 		OutCollisionSettings.ConvexElements.Emplace(
 			SourceConvexElems[ConvexIndex].VertexData, 
-			FBox3f(SourceConvexElems[ConvexIndex].ElemBox));
+			SourceConvexElems[ConvexIndex].ElemBox);
 	}
 
 	// Copy boxes

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -21,29 +21,29 @@ public:
 	FRuntimeMeshCollisionConvexMesh() : BoundingBox(ForceInit) { }
 	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(FBox(InVertexBuffer))
+		, BoundingBox(InVertexBuffer)
 	{
 	}
 	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(FBox(VertexBuffer))
+		, BoundingBox(VertexBuffer)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer, const FBox& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InBoundingBox)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer, const FBox& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(FBox(VertexBuffer))
+		, BoundingBox(InBoundingBox)
 	{
 	}
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
 	TArray<FVector> VertexBuffer;
-	//UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	FBox3f BoundingBox;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
+	FBox BoundingBox;
 
 	friend FArchive& operator <<(FArchive& Ar, FRuntimeMeshCollisionConvexMesh& Section)
 	{

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -392,7 +392,7 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionTexCoordStream
 	GENERATED_USTRUCT_BODY()
 
 private:
-	TArray<TArray<FVector2f>> Data;
+	TArray<TArray<FVector2D>> Data;
 
 public:
 	FRuntimeMeshCollisionTexCoordStream()
@@ -451,22 +451,22 @@ public:
 		Data[ChannelId].Empty(Slack);
 	}
 
-	FORCEINLINE int32 Add(int32 ChannelId, const FVector2f& NewTexCoord)
+	FORCEINLINE int32 Add(int32 ChannelId, const FVector2D& NewTexCoord)
 	{
 		return Data[ChannelId].Add(NewTexCoord);
 	}
 
-	FORCEINLINE FVector2f GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
+	FORCEINLINE FVector2D GetTexCoord(int32 ChannelId, int32 TexCoordIndex) const
 	{
 		return Data[ChannelId][TexCoordIndex];
 	}
 
-	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2f& NewTexCoord)
+	FORCEINLINE void SetTexCoord(int32 ChannelId, int32 TexCoordIndex, const FVector2D& NewTexCoord)
 	{
 		Data[ChannelId][TexCoordIndex] = NewTexCoord;
 	}
 private:
-	TArray<TArray<FVector2f>>&& TakeContents()
+	TArray<TArray<FVector2D>>&& TakeContents()
 	{
 		return MoveTemp(Data);
 	}

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -19,29 +19,29 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshCollisionConvexMesh
 
 public:
 	FRuntimeMeshCollisionConvexMesh() : BoundingBox(ForceInit) { }
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(InVertexBuffer)
+		, BoundingBox(FBox(InVertexBuffer))
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(VertexBuffer)
+		, BoundingBox(FBox(VertexBuffer))
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(const TArray<FVector3f>& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(const TArray<FVector>& InVertexBuffer, const FBox3f& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
 		, BoundingBox(InBoundingBox)
 	{
 	}
-	FRuntimeMeshCollisionConvexMesh(TArray<FVector3f>&& InVertexBuffer, const FBox3f& InBoundingBox)
+	FRuntimeMeshCollisionConvexMesh(TArray<FVector>&& InVertexBuffer, const FBox3f& InBoundingBox)
 		: VertexBuffer(InVertexBuffer)
-		, BoundingBox(VertexBuffer)
+		, BoundingBox(FBox(VertexBuffer))
 	{
 	}
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
-	TArray<FVector3f> VertexBuffer;
+	TArray<FVector> VertexBuffer;
 	//UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RuntimeMesh|Collision|Convex")
 	FBox3f BoundingBox;
 


### PR DESCRIPTION
Keeping engine-expected types and casting individual vectors from/to `FVector2/3 <-> FVector2f/3f` where applicable, instead of converting entire arrays.